### PR TITLE
feat: devnav header + tailwind glob

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,12 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Onboarding, Quiz, Match, Admin } from './pages';
+import DevNav from './components/DevNav';
 
 export default function App() {
   return (
     <BrowserRouter>
+      {import.meta.env.DEV && <DevNav />}
       <Routes>
         <Route path="/" element={<Navigate to="/onboarding" replace />} />
         <Route path="/onboarding" element={<Onboarding />} />

--- a/src/components/DevNav.tsx
+++ b/src/components/DevNav.tsx
@@ -1,0 +1,14 @@
+// DevNav.tsx – dev navigation header
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function DevNav() {
+  return (
+    <nav className="flex gap-4 p-2 bg-gray-200">
+      <Link to="/onboarding">Onboarding</Link>
+      <Link to="/quiz">Quiz</Link>
+      <Link to="/match">Match</Link>
+      <Link to="/admin">Admin</Link>
+    </nav>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  content: ['./src/**/*.{ts,tsx}'],
+  content: ['./src/**/*.{ts,tsx,html}'],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- add DevNav navigation header for development
- show the header only when running in dev mode
- broaden Tailwind content glob

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c896cd6788328baf7d61debf951f6