### PR TITLE
feat: quiz context and stepper

### DIFF
--- a/src/context/QuizContext.tsx
+++ b/src/context/QuizContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useReducer, useContext } from 'react';
+
+type Answers = Record<string, string | number>;
+
+interface QuizState {
+  answers: Answers;
+}
+
+type Action = {
+  type: 'SET_ANSWER';
+  questionId: string;
+  value: string | number;
+};
+
+function reducer(state: QuizState, action: Action): QuizState {
+  switch (action.type) {
+    case 'SET_ANSWER':
+      return { ...state, answers: { ...state.answers, [action.questionId]: action.value } };
+    default:
+      return state;
+  }
+}
+
+interface QuizContextValue {
+  answers: Answers;
+  setAnswer: (id: string, value: string | number) => void;
+}
+
+const QuizContext = createContext<QuizContextValue | undefined>(undefined);
+
+export const QuizProvider: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, { answers: {} });
+  const setAnswer = (id: string, value: string | number) => {
+    dispatch({ type: 'SET_ANSWER', questionId: id, value });
+  };
+  return (
+    <QuizContext.Provider value={{ answers: state.answers, setAnswer }}>
+      {children}
+    </QuizContext.Provider>
+  );
+};
+
+export function useQuiz() {
+  const ctx = useContext(QuizContext);
+  if (!ctx) throw new Error('useQuiz must be used within QuizProvider');
+  return ctx;
+}

--- a/src/data/layerA.ts
+++ b/src/data/layerA.ts
@@ -1,0 +1,5 @@
+export default [
+  { id: 'a1', text: 'Favorite color?', type: 'radio', options: ['Red', 'Green', 'Blue'] },
+  { id: 'a2', text: 'Age', type: 'slider', min: 18, max: 60 },
+  { id: 'a3', text: 'Country', type: 'select', options: ['USA', 'Canada', 'UK'] },
+];

--- a/src/data/layerB.ts
+++ b/src/data/layerB.ts
@@ -1,0 +1,4 @@
+export default [
+  { id: 'b1', text: 'Pet preference?', type: 'radio', options: ['Dog', 'Cat', 'None'] },
+  { id: 'b2', text: 'Happiness level', type: 'slider', min: 1, max: 10 },
+];

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -1,5 +1,117 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { QuizProvider, useQuiz } from '../context/QuizContext';
+import layerA from '../data/layerA';
+import layerB from '../data/layerB';
+
+function QuestionList({ questions }: { questions: any[] }) {
+  const { answers, setAnswer } = useQuiz();
+
+  return (
+    <div className="flex flex-col gap-4">
+      {questions.map((q) => (
+        <div key={q.id} className="flex flex-col gap-2">
+          <label className="font-semibold">{q.text}</label>
+          {q.type === 'radio' && (
+            <div className="flex gap-2">
+              {q.options.map((o: string) => (
+                <label key={o} className="flex items-center gap-1">
+                  <input
+                    type="radio"
+                    name={q.id}
+                    value={o}
+                    checked={answers[q.id] === o}
+                    onChange={() => setAnswer(q.id, o)}
+                  />
+                  {o}
+                </label>
+              ))}
+            </div>
+          )}
+          {q.type === 'slider' && (
+            <input
+              type="range"
+              min={q.min}
+              max={q.max}
+              value={answers[q.id] ?? q.min}
+              onChange={(e) => setAnswer(q.id, Number(e.target.value))}
+            />
+          )}
+          {q.type === 'select' && (
+            <select
+              value={answers[q.id] ?? ''}
+              onChange={(e) => setAnswer(q.id, e.target.value)}
+            >
+              <option value="" disabled>
+                Select...
+              </option>
+              {q.options.map((o: string) => (
+                <option key={o} value={o}>
+                  {o}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function QuizInner() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState(0);
+  const { answers } = useQuiz();
+  const layers = [layerA, layerB];
+  const questions = step < 2 ? layers[step] : [...layerA, ...layerB];
+
+  const allAnswered =
+    step < 2 && questions.every((q) => answers[q.id] !== undefined && answers[q.id] !== '');
+
+  const handleNext = () => setStep((s) => s + 1);
+  const handleSubmit = () => navigate('/myqr');
+
+  return (
+    <div className="p-4 flex flex-col gap-4">
+      {step < 2 ? (
+        <QuestionList questions={questions} />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {questions.map((q) => (
+            <div key={q.id} className="border p-2">
+              <span className="font-semibold mr-2">{q.text}:</span>
+              <span>{String(answers[q.id])}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex gap-2">
+        {step < 2 && (
+          <button
+            onClick={handleNext}
+            disabled={!allAnswered}
+            className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
+          >
+            Next
+          </button>
+        )}
+        {step === 2 && (
+          <button
+            onClick={handleSubmit}
+            className="bg-green-500 text-white px-4 py-2 rounded"
+          >
+            Submit
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export default function Quiz() {
-  return <div className="text-green-600 text-3xl">Quiz</div>;
+  return (
+    <QuizProvider>
+      <QuizInner />
+    </QuizProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- add a quiz context using useReducer
- create dummy question data for layer A and B
- implement stepper-based quiz page showing questions and review

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8b0be3e483289ec67036cbd775d3