### PR TITLE
Add rotating QR page

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
     "supabase-js": "^2.39.8",
-    "zod": "^3.22.2"
+    "zod": "^3.22.2",
+    "uuid": "^9.0.0",
+    "qrcode.react": "^1.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Onboarding, Quiz, Match, Admin } from './pages';
+import MyQR from './pages/MyQR';
 import DevNav from './components/DevNav';
 
 export default function App() {
@@ -12,6 +13,7 @@ export default function App() {
         <Route path="/" element={<Navigate to="/onboarding" replace />} />
         <Route path="/onboarding" element={<Onboarding />} />
         <Route path="/quiz" element={<Quiz />} />
+        <Route path="/myqr" element={<MyQR />} />
         <Route path="/match" element={<Match />} />
         <Route path="/admin" element={<Admin />} />
       </Routes>

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -1,0 +1,11 @@
+import { supabase } from '../supabaseClient';
+
+export async function saveSession(
+  token: string,
+  eventCode: string,
+  answers: Record<string, string | number>
+) {
+  await supabase
+    .from('sessions')
+    .upsert({ token, event_code: eventCode, answers });
+}

--- a/src/pages/MyQR.tsx
+++ b/src/pages/MyQR.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { QRCode } from 'qrcode.react';
+import { v4 as uuidv4 } from 'uuid';
+import { useEvent } from '../context/EventContext';
+import { useQuiz } from '../context/QuizContext';
+import { saveSession } from '../api/sessions';
+
+export default function MyQR() {
+  const { eventCode } = useEvent();
+  const { answers } = useQuiz();
+  const [token, setToken] = useState('');
+
+  useEffect(() => {
+    const generate = async () => {
+      const newToken = uuidv4();
+      setToken(newToken);
+      await saveSession(newToken, eventCode, answers);
+    };
+    generate();
+    const id = setInterval(() => setToken(uuidv4()), 90_000);
+    return () => clearInterval(id);
+  }, [eventCode, answers]);
+
+  const payload = JSON.stringify({ event: eventCode, token, ts: Date.now() });
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen">
+      <QRCode value={payload} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `uuid` and `qrcode.react` dependencies
- add `/myqr` page with rotating QR code and session upsert
- wire the new page into the router
- create `saveSession` API helper

## Testing
- `pnpm install` *(fails: Forbidden 403)*
- `pnpm build` *(fails: node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c8bd8f2bc832894f701aea2dbafe2