### PR TITLE
Add scan page with QR reader

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "supabase-js": "^2.39.8",
     "zod": "^3.22.2",
     "uuid": "^9.0.0",
-    "qrcode.react": "^1.0.0"
+    "qrcode.react": "^1.0.0",
+    "html5-qrcode": "^2.3.9"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Onboarding, Quiz, Match, Admin } from './pages';
 import MyQR from './pages/MyQR';
+import Scan from './pages/Scan';
 import DevNav from './components/DevNav';
 
 export default function App() {
@@ -14,6 +15,7 @@ export default function App() {
         <Route path="/onboarding" element={<Onboarding />} />
         <Route path="/quiz" element={<Quiz />} />
         <Route path="/myqr" element={<MyQR />} />
+        <Route path="/scan" element={<Scan />} />
         <Route path="/match" element={<Match />} />
         <Route path="/admin" element={<Admin />} />
       </Routes>

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ErrorBanner({ message }: { message: string }) {
+  if (!message) return null;
+  return (
+    <div className="bg-red-500 text-white p-2 rounded w-full text-center">
+      {message}
+    </div>
+  );
+}

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Spinner() {
+  return (
+    <div className="flex items-center justify-center py-4">
+      <div className="h-12 w-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
+}

--- a/src/pages/Scan.tsx
+++ b/src/pages/Scan.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Html5Qrcode } from 'html5-qrcode';
+import { useNavigate } from 'react-router-dom';
+import Spinner from '../components/Spinner';
+import ErrorBanner from '../components/ErrorBanner';
+import { useEvent } from '../context/EventContext';
+
+export default function Scan() {
+  const { eventCode } = useEvent();
+  const navigate = useNavigate();
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const scannerRef = useRef<HTMLDivElement>(null);
+  const qrRef = useRef<Html5Qrcode>();
+
+  useEffect(() => {
+    if (!scannerRef.current) return;
+    const id = 'qr-region';
+    scannerRef.current.id = id;
+    const html5 = new Html5Qrcode(id);
+    qrRef.current = html5;
+    html5
+      .start(
+        { facingMode: 'environment' },
+        { fps: 10, qrbox: { width: 250, height: 250 } },
+        (text) => {
+          try {
+            const { event, token } = JSON.parse(text);
+            if (event !== eventCode) {
+              setError('Invalid event code');
+              return;
+            }
+            navigate('/match', { state: { peerToken: token } });
+          } catch {
+            setError('Invalid QR');
+          }
+        },
+        (err) => {
+          if (
+            typeof err === 'string' &&
+            (err.toLowerCase().includes('permission') ||
+              err.toLowerCase().includes('camera'))
+          ) {
+            setError('');
+          }
+        }
+      )
+      .then(() => setLoading(false))
+      .catch((err) => {
+        if (
+          typeof err === 'string' &&
+          (err.toLowerCase().includes('permission') ||
+            err.toLowerCase().includes('camera'))
+        ) {
+          setError('');
+        } else {
+          setError(String(err));
+        }
+        setLoading(false);
+      });
+
+    return () => {
+      html5
+        .stop()
+        .then(() => html5.clear())
+        .catch(() => {});
+    };
+  }, [eventCode, navigate]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      {error && <ErrorBanner message={error} />}
+      {loading && <Spinner />}
+      <div ref={scannerRef} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add QR scan page to navigate on token match
- show spinner while loading camera and banner on errors
- wire up /scan route
- include html5-qrcode dependency

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8d110c648328b9048d014f4ecfba