### PR TITLE
feat: matcher and result UI

### DIFF
--- a/src/algo/matcher.ts
+++ b/src/algo/matcher.ts
@@ -1,0 +1,16 @@
+export interface MatchOutcome {
+  score: number;
+  color: 'green' | 'yellow' | 'red';
+}
+
+export function computeMatch(
+  my: Record<string, string | number>,
+  peer: Record<string, string | number>
+): MatchOutcome {
+  const score = Math.random();
+  let color: MatchOutcome['color'];
+  if (score >= 0.66) color = 'green';
+  else if (score >= 0.33) color = 'yellow';
+  else color = 'red';
+  return { score, color };
+}

--- a/src/components/MatchResult.tsx
+++ b/src/components/MatchResult.tsx
@@ -1,3 +1,22 @@
-// MatchResult.tsx – displays match color/% result
 import React from 'react';
-export default function MatchResult() { return null; }
+
+export default function MatchResult({
+  color,
+  score,
+}: {
+  color: 'green' | 'yellow' | 'red';
+  score: number;
+}) {
+  const percent = Math.round(score * 100);
+  return (
+    <div className="flex flex-col items-center gap-4 mt-8">
+      <div
+        className="w-40 h-40 rounded-full"
+        style={{ backgroundColor: color }}
+      />
+      <div className="text-5xl font-bold" style={{ color }}>
+        {percent}%
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -1,5 +1,38 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { supabase } from '../supabaseClient';
+import { useQuiz } from '../context/QuizContext';
+import MatchResult from '../components/MatchResult';
+import { computeMatch, MatchOutcome } from '../algo/matcher';
 
 export default function Match() {
-  return <div className="text-red-600 text-3xl">Match</div>;
+  const location = useLocation() as { state?: { peerToken?: string } };
+  const peerToken = location.state?.peerToken;
+  const { answers } = useQuiz();
+  const [result, setResult] = useState<MatchOutcome | null>(null);
+
+  useEffect(() => {
+    const fetchPeer = async () => {
+      if (!peerToken) return;
+      const { data } = await supabase
+        .from('sessions')
+        .select('answers')
+        .eq('token', peerToken)
+        .single();
+      if (data?.answers) {
+        const res = computeMatch(
+          answers,
+          data.answers as Record<string, string | number>
+        );
+        setResult(res);
+      }
+    };
+    fetchPeer();
+  }, [peerToken, answers]);
+
+  if (!result) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return <MatchResult color={result.color} score={result.score} />;
 }


### PR DESCRIPTION
## Summary
- add matcher algorithm with random scoring
- display match colour and percentage
- fetch peer answers and compute match result

## Testing
- `pnpm install` *(fails: registry blocked)*
- `pnpm build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8e2fccb08328a6412a6513664476