### PR TITLE
feat: add sessions table and RLS setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,10 @@ This project uses pnpm with Vite and React.
 pnpm install
 pnpm dev
 ```
+
+### Supabase Setup
+
+Run `supabase/init.sql` in your project database to create the `sessions` table.
+After running the script, enable **Row Level Security (RLS)** for `sessions` in
+the Supabase dashboard and add a policy allowing users to read only rows where
+`event_code` matches their JWT context.

--- a/supabase/init.sql
+++ b/supabase/init.sql
@@ -1,0 +1,12 @@
+-- Database initialization for Beep
+
+create table if not exists sessions (
+  token text primary key,
+  event_code text not null,
+  answers jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+-- Row Level Security
+-- Enable RLS in the Supabase dashboard and add a policy:
+-- allow users to select only rows where event_code = auth.jwt() ->> 'event_code';


### PR DESCRIPTION
## Summary
- add Supabase `sessions` table SQL
- instruct how to enable RLS and reference policy

## Testing
- `pnpm build` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c8f28950883288362819d5461ce90