### PR TITLE
Implement admin dashboard stats

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -1,4 +1,15 @@
 import { supabase } from '../supabaseClient';
+import { computeMatch } from '../algo/matcher';
+
+export interface Stats {
+  participants: number;
+  avgScore: number;
+  colors: {
+    green: number;
+    yellow: number;
+    red: number;
+  };
+}
 
 export async function saveSession(
   token: string,
@@ -8,4 +19,32 @@ export async function saveSession(
   await supabase
     .from('sessions')
     .upsert({ token, event_code: eventCode, answers });
+}
+
+export async function getStats(eventCode?: string): Promise<Stats> {
+  let query = supabase.from('sessions').select('answers');
+  if (eventCode) {
+    query = query.eq('event_code', eventCode);
+  }
+  const { data, error } = await query;
+  if (error) throw error;
+
+  const rows = (data ?? []) as { answers: Record<string, string | number> }[];
+  const participants = rows.length;
+  const colors = { green: 0, yellow: 0, red: 0 };
+  let scoreSum = 0;
+  let count = 0;
+
+  for (let i = 0; i < rows.length; i++) {
+    for (let j = i + 1; j < rows.length; j++) {
+      const { score, color } = computeMatch(rows[i].answers, rows[j].answers);
+      scoreSum += score;
+      count++;
+      colors[color]++;
+    }
+  }
+
+  const avgScore = count ? scoreSum / count : 0;
+
+  return { participants, avgScore, colors };
 }

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,5 +1,62 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useEvent } from '../context/EventContext';
+import { getStats, Stats } from '../api/sessions';
+import Spinner from '../components/Spinner';
+import ErrorBanner from '../components/ErrorBanner';
 
 export default function Admin() {
-  return <div className="text-purple-600 text-3xl">Admin</div>;
+  const { eventCode } = useEvent();
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await getStats(eventCode);
+        setStats(res);
+      } catch (err: any) {
+        setError(err.message ?? String(err));
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [eventCode]);
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  return (
+    <div className="p-4 flex flex-col gap-4">
+      {error && <ErrorBanner message={error} />}
+      {stats && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+          <div className="border rounded p-4 text-center">
+            <div className="text-sm text-gray-500">Participants</div>
+            <div className="text-2xl font-bold">{stats.participants}</div>
+          </div>
+          <div className="border rounded p-4 text-center">
+            <div className="text-sm text-gray-500">Avg. Score</div>
+            <div className="text-2xl font-bold">
+              {stats.avgScore.toFixed(2)}
+            </div>
+          </div>
+          <div className="border rounded p-4 text-center">
+            <div className="text-sm text-gray-500">Green</div>
+            <div className="text-2xl font-bold">{stats.colors.green}</div>
+          </div>
+          <div className="border rounded p-4 text-center">
+            <div className="text-sm text-gray-500">Yellow</div>
+            <div className="text-2xl font-bold">{stats.colors.yellow}</div>
+          </div>
+          <div className="border rounded p-4 text-center">
+            <div className="text-sm text-gray-500">Red</div>
+            <div className="text-2xl font-bold">{stats.colors.red}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- compute event statistics in API
- display participant and match info on admin page

## Testing
- `pnpm build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c900f95f483289b4a85137e7febf3