### PR TITLE
Enable basic PWA install

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/react-dom": "^18.2.0",
     "typescript": "^5.4.0",
     "vite": "^5.0.0",
+    "vite-plugin-pwa": "^0.18.0",
     "tailwindcss": "^3.4.0",
     "postcss": "^8.4.0",
     "autoprefixer": "^10.4.0"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,2 +1,3 @@
 // Service worker placeholder
 self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { EventProvider } from './context/EventContext';
+import { registerSW } from 'virtual:pwa-register';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
@@ -10,3 +11,5 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     </EventProvider>
   </React.StrictMode>
 );
+
+registerSW({ immediate: true });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 // Vite configuration for React PWA
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate'
+    })
+  ]
 });


### PR DESCRIPTION
## Summary
- add vite-plugin-pwa
- configure plugin with autoUpdate
- register service worker in React entry
- expand placeholder service worker to claim clients

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c930f661c832884d3981000914cb9