### PR TITLE
Replace random matcher with deterministic weighted algorithm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/__tests__/matcher.test.ts
+++ b/src/__tests__/matcher.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { UserAnswer } from '../data/types';
+
+vi.mock('../data/layerA', () => ({
+  layerA: [
+    { id: 'q1', type: 'yesno', weight: 2 },
+    { id: 'q2', type: 'slider', weight: 3 },
+    { id: 'q3', type: 'select', options: ['a', 'b'], weight: 1 },
+  ],
+}));
+
+vi.mock('../data/layerB', () => ({
+  layerB: [
+    { id: 'b1', type: 'yesno' },
+    { id: 'b2', type: 'slider' },
+  ],
+}));
+
+import { computeMatch } from '../algo/matcher';
+
+describe('computeMatch', () => {
+  it('identical answers → green & ~1.0', () => {
+    const answers: Record<string, UserAnswer> = {
+      q1: { value: 'yes' },
+      q2: { value: 3 },
+      q3: { value: 'a' },
+      b1: { value: 'no', importance: 5 },
+      b2: { value: 4, importance: 1 },
+    };
+    const res = computeMatch(answers, answers);
+    expect(res.color).toBe('green');
+    expect(res.score).toBeGreaterThan(0.99);
+  });
+
+  it('deal-breaker mismatch → red & 0', () => {
+    const me: Record<string, UserAnswer> = {
+      b1: { value: 'yes', importance: 5, isDealBreaker: true },
+    };
+    const other: Record<string, UserAnswer> = {
+      b1: { value: 'no', importance: 5 },
+    };
+    const res = computeMatch(me, other);
+    expect(res.color).toBe('red');
+    expect(res.score).toBe(0);
+  });
+
+  it('partial alignment with mixed weights → yellow between 0.5 and 0.8', () => {
+    const me: Record<string, UserAnswer> = {
+      q1: { value: 'yes' }, // match weight2
+      q2: { value: 4 }, // slider close to peer weight3
+      b1: { value: 'yes', importance: 1 }, // mismatch low weight
+      b2: { value: 3, importance: 5 }, // slider mid diff high weight
+    };
+    const peer: Record<string, UserAnswer> = {
+      q1: { value: 'yes' },
+      q2: { value: 5 },
+      b1: { value: 'no', importance: 1 },
+      b2: { value: 5, importance: 5 },
+    };
+    const res = computeMatch(me, peer);
+    expect(res.color).toBe('yellow');
+    expect(res.score).toBeGreaterThan(0.5);
+    expect(res.score).toBeLessThan(0.8);
+  });
+
+  it('sliders distance reduces similarity', () => {
+    const me: Record<string, UserAnswer> = {
+      b2: { value: 1, importance: 3 },
+    };
+    const peer: Record<string, UserAnswer> = {
+      b2: { value: 3, importance: 3 },
+    };
+    const res = computeMatch(me, peer);
+    expect(res.score).toBeCloseTo(0.5);
+    expect(res.color).toBe('yellow');
+  });
+});

--- a/src/algo/matcher.ts
+++ b/src/algo/matcher.ts
@@ -1,16 +1,58 @@
+import { layerA } from '../data/layerA';
+import { layerB } from '../data/layerB';
+import type { Question, UserAnswer } from '../data/types';
+
 export interface MatchOutcome {
   score: number;
   color: 'green' | 'yellow' | 'red';
 }
 
+function similarity(q: Question, a: string | number, b: string | number): number {
+  switch (q.type) {
+    case 'yesno':
+    case 'select':
+      return a === b ? 1 : 0;
+    case 'slider':
+      return 1 - Math.abs(Number(a) - Number(b)) / 4;
+    default:
+      return 0;
+  }
+}
+
 export function computeMatch(
-  my: Record<string, string | number>,
-  peer: Record<string, string | number>
+  myAnswers: Record<string, UserAnswer>,
+  peerAnswers: Record<string, UserAnswer>
 ): MatchOutcome {
-  const score = Math.random();
-  let color: MatchOutcome['color'];
-  if (score >= 0.66) color = 'green';
-  else if (score >= 0.33) color = 'yellow';
-  else color = 'red';
+  let total = 0;
+  let weightSum = 0;
+
+  const process = (
+    questions: Question[],
+    getWeight: (q: Question, a: UserAnswer) => number
+  ): boolean => {
+    for (const q of questions) {
+      const my = myAnswers[q.id];
+      const peer = peerAnswers[q.id];
+      if (!my || !peer) continue;
+
+      const sim = similarity(q, my.value, peer.value);
+      const isDeal = q.dealBreaker || my.isDealBreaker || peer.isDealBreaker;
+      const incompatible = q.type === 'slider' ? sim < 0.75 : sim < 1;
+      if (isDeal && incompatible) return true;
+
+      const weight = getWeight(q, my);
+      total += sim * weight;
+      weightSum += weight;
+    }
+    return false;
+  };
+
+  if (process(layerA, (q) => q.weight ?? 1)) return { score: 0, color: 'red' };
+  if (process(layerB, (_q, a) => a.importance ?? 3))
+    return { score: 0, color: 'red' };
+
+  const score = weightSum ? total / weightSum : 0;
+  const color: MatchOutcome['color'] =
+    score >= 0.8 ? 'green' : score >= 0.5 ? 'yellow' : 'red';
   return { score, color };
 }

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../supabaseClient';
 import { computeMatch } from '../algo/matcher';
+import type { UserAnswer } from '../data/types';
 
 export interface Stats {
   participants: number;
@@ -14,7 +15,7 @@ export interface Stats {
 export async function saveSession(
   token: string,
   eventCode: string,
-  answers: Record<string, string | number>
+  answers: Record<string, UserAnswer>
 ) {
   await supabase
     .from('sessions')
@@ -29,7 +30,7 @@ export async function getStats(eventCode?: string): Promise<Stats> {
   const { data, error } = await query;
   if (error) throw error;
 
-  const rows = (data ?? []) as { answers: Record<string, string | number> }[];
+  const rows = (data ?? []) as { answers: Record<string, UserAnswer> }[];
   const participants = rows.length;
   const colors = { green: 0, yellow: 0, red: 0 };
   let scoreSum = 0;

--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -4,6 +4,7 @@ import { supabase } from '../supabaseClient';
 import { useQuiz } from '../contexts/QuizContext';
 import MatchResult from '../components/MatchResult';
 import { computeMatch, MatchOutcome } from '../algo/matcher';
+import type { UserAnswer } from '../data/types';
 
 export default function Match() {
   const location = useLocation() as { state?: { peerToken?: string } };
@@ -22,7 +23,7 @@ export default function Match() {
       if (data?.answers) {
         const res = computeMatch(
           answers,
-          data.answers as Record<string, string | number>
+          data.answers as Record<string, UserAnswer>
         );
         setResult(res);
       }


### PR DESCRIPTION
## Summary
- implement deterministic compatibility scoring with weights and deal-breakers
- update session and match pages to use new answer shape
- add matcher tests and test script

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/typescript: Forbidden - 403)*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f100fbaec83289516e51d32c848bf