### PR TITLE
feat: validate QR payloads and handle scanner errors

### DIFF
--- a/src/__tests__/qr-schema.test.ts
+++ b/src/__tests__/qr-schema.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { QrPayload } from '../schemas/qr';
+
+const base = {
+  event: '1234',
+  token: '11111111-1111-1111-1111-111111111111',
+  ts: Date.now(),
+  exp: Date.now() + 120_000,
+};
+
+describe('QrPayload schema', () => {
+  it('accepts valid payload', () => {
+    expect(QrPayload.safeParse(base).success).toBe(true);
+  });
+
+  it('rejects bad event', () => {
+    expect(QrPayload.safeParse({ ...base, event: 'abcd' }).success).toBe(false);
+  });
+
+  it('rejects bad uuid', () => {
+    expect(QrPayload.safeParse({ ...base, token: 'not-uuid' }).success).toBe(false);
+  });
+
+  it('detects expired exp', () => {
+    const parsed = QrPayload.safeParse({ ...base, exp: Date.now() - 1 });
+    expect(parsed.success && Date.now() < parsed.data.exp).toBe(false);
+  });
+});

--- a/src/pages/MyQR.tsx
+++ b/src/pages/MyQR.tsx
@@ -9,23 +9,34 @@ export default function MyQR() {
   const { eventCode } = useEvent();
   const { answers } = useQuiz();
   const [token, setToken] = useState('');
+  const [payload, setPayload] = useState('');
 
   useEffect(() => {
     const generate = async () => {
       const newToken = uuidv4();
+      const exp = Date.now() + 120_000;
       setToken(newToken);
+      setPayload(
+        JSON.stringify({ event: eventCode, token: newToken, ts: Date.now(), exp })
+      );
       await saveSession(newToken, eventCode, answers);
     };
     generate();
-    const id = setInterval(() => setToken(uuidv4()), 90_000);
+    const id = setInterval(generate, 90_000);
     return () => clearInterval(id);
   }, [eventCode, answers]);
 
-  const payload = JSON.stringify({ event: eventCode, token, ts: Date.now() });
+  const copy = () => {
+    navigator.clipboard?.writeText(token).catch(() => {});
+  };
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen">
-      <QRCode value={payload} />
+    <div className="flex flex-col items-center justify-center h-screen gap-2">
+      {payload && <QRCode value={payload} />}
+      <button onClick={copy} className="text-xs underline">
+        copy
+      </button>
+      <p className="text-xs text-gray-500">rotates every 90s</p>
     </div>
   );
 }

--- a/src/pages/Scan.tsx
+++ b/src/pages/Scan.tsx
@@ -4,74 +4,147 @@ import { useNavigate } from 'react-router-dom';
 import Spinner from '../components/Spinner';
 import ErrorBanner from '../components/ErrorBanner';
 import { useEvent } from '../context/EventContext';
+import { QrPayload } from '../schemas/qr';
+import { z } from 'zod';
 
 export default function Scan() {
   const { eventCode } = useEvent();
   const navigate = useNavigate();
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
+  const [noCamera, setNoCamera] = useState(false);
+  const [manualToken, setManualToken] = useState('');
   const scannerRef = useRef<HTMLDivElement>(null);
   const qrRef = useRef<Html5Qrcode>();
 
-  useEffect(() => {
+  const handleSuccess = (text: string) => {
+    try {
+      const parsedJson = JSON.parse(text);
+      const parsed = QrPayload.safeParse(parsedJson);
+      if (!parsed.success) throw new Error('bad');
+      const data = parsed.data;
+      if (data.event !== eventCode || Date.now() > data.exp) {
+        throw new Error('bad');
+      }
+      navigate('/match', { state: { peerToken: data.token } });
+    } catch {
+      qrRef.current?.pause(true);
+      setError('This QR is expired or not for this event.');
+    }
+  };
+
+  const handleError = (err: unknown) => {
+    const msg = String(err).toLowerCase();
+    if (msg.includes('permission') || msg.includes('camera')) {
+      setError('');
+    }
+  };
+
+  const startScanner = async () => {
     if (!scannerRef.current) return;
     const id = 'qr-region';
     scannerRef.current.id = id;
     const html5 = new Html5Qrcode(id);
     qrRef.current = html5;
-    html5
-      .start(
+    try {
+      await html5.start(
         { facingMode: 'environment' },
         { fps: 10, qrbox: { width: 250, height: 250 } },
-        (text) => {
-          try {
-            const { event, token } = JSON.parse(text);
-            if (event !== eventCode) {
-              setError('Invalid event code');
-              return;
-            }
-            navigate('/match', { state: { peerToken: token } });
-          } catch {
-            setError('Invalid QR');
-          }
-        },
-        (err) => {
-          if (
-            typeof err === 'string' &&
-            (err.toLowerCase().includes('permission') ||
-              err.toLowerCase().includes('camera'))
-          ) {
-            setError('');
-          }
+        handleSuccess,
+        handleError
+      );
+      setLoading(false);
+    } catch (err) {
+      const msg = String(err).toLowerCase();
+      if (msg.includes('permission')) {
+        setError('Camera permission denied. Enable camera in system settings.');
+      } else {
+        setError(String(err));
+      }
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    Html5Qrcode.getCameras()
+      .then((devices) => {
+        if (!devices.length) {
+          setNoCamera(true);
+          setLoading(false);
+          return;
         }
-      )
-      .then(() => setLoading(false))
-      .catch((err) => {
-        if (
-          typeof err === 'string' &&
-          (err.toLowerCase().includes('permission') ||
-            err.toLowerCase().includes('camera'))
-        ) {
-          setError('');
-        } else {
-          setError(String(err));
-        }
+        startScanner();
+      })
+      .catch(() => {
+        setError('Camera permission denied. Enable camera in system settings.');
         setLoading(false);
       });
 
     return () => {
+      const html5 = qrRef.current;
       html5
-        .stop()
+        ?.stop()
         .then(() => html5.clear())
         .catch(() => {});
     };
-  }, [eventCode, navigate]);
+  }, [eventCode]);
+
+  useEffect(() => {
+    const onVis = () => {
+      const qr = qrRef.current;
+      if (!qr) return;
+      if (document.hidden) qr.pause(true);
+      else if (!error) qr.resume();
+    };
+    document.addEventListener('visibilitychange', onVis);
+    return () => document.removeEventListener('visibilitychange', onVis);
+  }, [error]);
+
+  const handleRetry = () => {
+    setError('');
+    qrRef.current?.resume().catch(() => {});
+  };
+
+  const handleManualSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = z.string().uuid().safeParse(manualToken.trim());
+    if (parsed.success) {
+      navigate('/match', { state: { peerToken: parsed.data } });
+    } else {
+      setError('Invalid token');
+    }
+  };
 
   return (
     <div className="flex flex-col items-center gap-4 p-4">
       {error && <ErrorBanner message={error} />}
+      {error === 'This QR is expired or not for this event.' && (
+        <button
+          onClick={handleRetry}
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+        >
+          Retry
+        </button>
+      )}
       {loading && <Spinner />}
-      <div ref={scannerRef} />
+      {!noCamera ? (
+        <div ref={scannerRef} />
+      ) : (
+        <form onSubmit={handleManualSubmit} className="flex flex-col gap-2">
+          <input
+            value={manualToken}
+            onChange={(e) => setManualToken(e.target.value)}
+            className="border p-2"
+            placeholder="Enter token"
+          />
+          <button
+            type="submit"
+            className="bg-blue-500 text-white px-3 py-1 rounded"
+          >
+            Go
+          </button>
+        </form>
+      )}
     </div>
   );
 }

--- a/src/schemas/qr.ts
+++ b/src/schemas/qr.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const QrPayload = z.object({
+  event: z.string().regex(/^\d{4}$/),
+  token: z.string().uuid(),
+  ts: z.number().int().positive(),
+  exp: z.number().int().positive(),
+});
+
+export type QrPayloadT = z.infer<typeof QrPayload>;


### PR DESCRIPTION
## Summary
- add zod schema for QR code payloads
- expire and rotate tokens in MyQR with copy helper
- harden Scan with schema validation, TTL checks, camera error handling and manual token fallback
- test QR schema validation

## Testing
- ⚠️ `pnpm install` (registry access forbidden)
- ⚠️ `pnpm test` (vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_689f11d261388328b09a82c0502c2b5d