### PR TITLE
feat: polish PWA for offline reliability

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <title>Beep MVP</title>
   </head>
   <body>

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Offline</title>
+  </head>
+  <body>
+    <h1>You are offline</h1>
+    <p>Please check your internet connection.</p>
+    <a href="." >Retry</a>
+  </body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,3 +1,0 @@
-// Service worker placeholder
-self.addEventListener('install', () => self.skipWaiting());
-self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,7 +12,32 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
         <App />
       </QuizProvider>
     </EventProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );
 
-registerSW({ immediate: true });
+const updateServiceWorker = registerSW({
+  immediate: true,
+  onNeedRefresh() {
+    const toast = document.createElement('div');
+    toast.textContent = 'New version available — ';
+    const refresh = document.createElement('button');
+    refresh.textContent = 'Refresh';
+    toast.appendChild(refresh);
+    Object.assign(toast.style, {
+      position: 'fixed',
+      bottom: '1rem',
+      left: '1rem',
+      background: '#fff',
+      padding: '0.5rem 1rem',
+      border: '1px solid #ccc',
+      borderRadius: '4px',
+      zIndex: '1000',
+    });
+    refresh.style.marginLeft = '0.5rem';
+    refresh.addEventListener('click', async () => {
+      await updateServiceWorker();
+      location.reload();
+    });
+    document.body.appendChild(toast);
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,25 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
-      registerType: 'autoUpdate'
+      registerType: 'autoUpdate',
+      includeAssets: ['favicon.ico', 'logo.png'],
+      workbox: {
+        navigateFallback: '/index.html',
+        globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/[^/]+\/(.*)\.(?:png|jpg|jpeg|svg|webp)$/,
+            handler: 'StaleWhileRevalidate',
+          },
+          {
+            urlPattern: ({ request }) => request.destination === 'document',
+            handler: 'NetworkFirst',
+          },
+        ],
+        fallback: {
+          document: '/offline.html',
+        },
+      },
     })
   ]
 });


### PR DESCRIPTION
## Summary
- add iOS-friendly meta tags and apple-touch-icon
- configure VitePWA with runtime caching and offline fallback
- show update prompt when a new service worker is available

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f13a5d0888328a3aa4a1755438f21