### PR TITLE
fix: clean duplicate routes/imports, nullable Supabase client, guarded session API, safe Match fallback

### DIFF
--- a/src/pages/Match.tsx
+++ b/src/pages/Match.tsx
@@ -13,7 +13,6 @@ export default function Match() {
 
   useEffect(() => {
     const run = async () => {
-      // Demo mode: no backend → still show a result
       if (!supabase) {
         setResult(computeMatch(answers as Record<string, unknown>, {}));
         return;


### PR DESCRIPTION
## Summary
- simplify App routing with lazy-loaded pages
- allow nullable Supabase client and guard session APIs
- handle missing backend gracefully on Match page

## Testing
- `grep -c "<Routes>" src/App.tsx`
- `rg -n "import .* from './pages'" src/App.tsx`
- `rg -n "createClient\\(" src/supabaseClient.ts | wc -l`
- `rg -n "Record<string, unknown>" src/api/sessions.ts`
- `grep -c "Loading..." src/pages/Match.tsx`
- `npm test` *(fails: No test suite found / matcher expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68a3af7d41248328aac980cc58cd0015