### PR TITLE
feat: integrate inline Beep SVG logo and brand assets

### DIFF
--- a/docs/brandbook.md
+++ b/docs/brandbook.md
@@ -1,0 +1,37 @@
+# beep brandbook (mini)
+
+## Logo variants
+- **Ping (primary):** sonar/pulse mark (universal, simple)
+- **Traffic:** three-stack “lights” (tops to bottoms)
+- **Scan:** four QR corners with meet-dot
+- **Monogram:** geometric “b” in a circle
+
+All marks inherit `currentColor`. Use brand tokens in CSS to theme.
+
+```css
+:root {
+  --brand:#0f172a;
+  --beep-top:#ef4444; /* red */
+  --beep-mid:#f59e0b; /* yellow */
+  --beep-bot:#10b981; /* green  */
+}
+
+React usage
+import BeepLogo from '../components/BeepLogo';
+
+<BeepLogo withWordmark className="text-slate-900" />
+<BeepLogo variant="traffic" className="state-green" />
+<BeepLogo variant="scan" sizeEm={2} />
+
+State colors (traffic variant)
+.state-red   { color: var(--beep-top);  --beep-top: var(--beep-top); }
+.state-yellow{ color: var(--beep-mid);  --beep-mid: var(--beep-mid); }
+.state-green { color: var(--beep-bot);  --beep-bot: var(--beep-bot); }
+
+Favicons / PWA
+
+public/logo.svg is the app icon (scales cleanly).
+
+public/manifest.json points to logo.svg with "type": "image/svg+xml".
+
+vite.config.ts includes logo.svg in includeAssets.

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="/logo.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="22" cy="32" r="6" fill="#0f172a"/>
+  <path d="M32 24 A10 10 0 0 1 32 40" fill="none" stroke="#0f172a" stroke-width="4" stroke-linecap="round"/>
+  <path d="M38 18 A16 16 0 0 1 38 46" fill="none" stroke="#0f172a" stroke-width="4" stroke-linecap="round" opacity=".6"/>
+  <path d="M44 12 A22 22 0 0 1 44 52" fill="none" stroke="#0f172a" stroke-width="4" stroke-linecap="round" opacity=".3"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,10 +6,6 @@
   "background_color": "#ffffff",
   "theme_color": "#ffffff",
   "icons": [
-    {
-      "src": "logo.png",
-      "sizes": "512x512",
-      "type": "image/png"
-    }
+    { "src": "logo.svg", "sizes": "any", "type": "image/svg+xml" }
   ]
 }

--- a/src/components/BeepLogo.tsx
+++ b/src/components/BeepLogo.tsx
@@ -1,0 +1,88 @@
+// Reusable beep logo with variants that inherit currentColor.
+// Props: variant ('ping' | 'traffic' | 'scan' | 'monogram'), withWordmark, className.
+type Variant = 'ping' | 'traffic' | 'scan' | 'monogram';
+
+interface Props {
+  variant?: Variant;
+  withWordmark?: boolean;
+  className?: string;
+  sizeEm?: number; // optional; defaults to 1.6
+}
+
+function PingMark({ sizeEm = 1.6 }: { sizeEm?: number }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"
+         width={`${sizeEm}em`} height={`${sizeEm}em`} aria-hidden="true">
+      <circle cx="22" cy="32" r="6" fill="currentColor"/>
+      <path d="M32 24 A10 10 0 0 1 32 40" fill="none"
+            stroke="currentColor" strokeWidth="4" strokeLinecap="round"/>
+      <path d="M38 18 A16 16 0 0 1 38 46" fill="none"
+            stroke="currentColor" strokeWidth="4" strokeLinecap="round" opacity=".6"/>
+      <path d="M44 12 A22 22 0 0 1 44 52" fill="none"
+            stroke="currentColor" strokeWidth="4" strokeLinecap="round" opacity=".3"/>
+    </svg>
+  );
+}
+
+function TrafficMark({ sizeEm = 1.6 }: { sizeEm?: number }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"
+         width={`${sizeEm}em`} height={`${sizeEm}em`} aria-hidden="true">
+      <rect x="18" y="8" width="28" height="48" rx="14"
+            fill="none" stroke="currentColor" strokeWidth="4"/>
+      <circle cx="32" cy="20" r="6" fill="var(--beep-top, currentColor)" opacity=".45"/>
+      <circle cx="32" cy="32" r="6" fill="var(--beep-mid, currentColor)" opacity=".7"/>
+      <circle cx="32" cy="44" r="6" fill="var(--beep-bot, currentColor)"/>
+    </svg>
+  );
+}
+
+function ScanMark({ sizeEm = 1.6 }: { sizeEm?: number }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"
+         width={`${sizeEm}em`} height={`${sizeEm}em`} aria-hidden="true">
+      <g fill="none" stroke="currentColor" strokeWidth="4" strokeLinecap="round">
+        <path d="M12 22 V12 H22" /><path d="M42 12 H52 V22" />
+        <path d="M12 42 V52 H22" /><path d="M52 42 V52 H42" />
+      </g>
+      <circle cx="32" cy="32" r="6" fill="currentColor"/>
+    </svg>
+  );
+}
+
+function MonogramMark({ sizeEm = 1.6 }: { sizeEm?: number }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"
+         width={`${sizeEm}em`} height={`${sizeEm}em`} aria-hidden="true">
+      <circle cx="32" cy="32" r="28" fill="none" stroke="currentColor" strokeWidth="4"/>
+      <rect x="24" y="18" width="8" height="28" rx="4" fill="currentColor"/>
+      <circle cx="36" cy="32" r="10" fill="none" stroke="currentColor" strokeWidth="8"/>
+    </svg>
+  );
+}
+
+export default function BeepLogo({
+  variant = 'ping',
+  withWordmark = false,
+  className = '',
+  sizeEm = 1.6,
+}: Props) {
+  const Mark =
+    variant === 'traffic' ? TrafficMark :
+    variant === 'scan'    ? ScanMark    :
+    variant === 'monogram'? MonogramMark: PingMark;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-[0.55ch] text-slate-900 ${className}`}
+      role="img" aria-label="beep"
+    >
+      <Mark sizeEm={sizeEm} />
+      {withWordmark && (
+        <strong style={{ font: '600 1rem/1 system-ui,Segoe UI,Inter,Arial' }}>
+          beep
+        </strong>
+      )}
+    </span>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,13 @@
 // Header.tsx – shared header
 import React from 'react';
-export default function Header() { return null; }
+import BeepLogo from './BeepLogo';
+
+export default function Header() {
+  return (
+    <header className="flex items-center p-4">
+      <a href="/" className="inline-flex items-center">
+        <BeepLogo withWordmark />
+      </a>
+    </header>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -15,3 +15,13 @@ body {
 #root {
   min-height: 100vh;
 }
+
+:root {
+  --brand:#0f172a;
+  --beep-top:#ef4444;
+  --beep-mid:#f59e0b;
+  --beep-bot:#10b981;
+}
+.state-red   { color: var(--beep-top);  --beep-top: var(--beep-top); }
+.state-yellow{ color: var(--beep-mid);  --beep-mid: var(--beep-mid); }
+.state-green { color: var(--beep-bot);  --beep-bot: var(--beep-bot); }

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { z } from 'zod';
 import { useEvent } from '../context/EventContext';
+import BeepLogo from '../components/BeepLogo';
 
 export default function Onboarding() {
   const { setEventCode } = useEvent();
@@ -20,7 +21,7 @@ export default function Onboarding() {
 
   return (
     <div className="flex flex-col items-center justify-center h-screen gap-4">
-      <img src="/logo.png" alt="Beep logo" className="w-32" />
+      <BeepLogo withWordmark className="text-7xl" />
       <form onSubmit={handleSubmit} className="flex flex-col items-center gap-2">
         <input
           type="text"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     basicSsl(),
     VitePWA({
       registerType: 'autoUpdate',
-      includeAssets: ['favicon.ico', 'logo.png'],
+      includeAssets: ['favicon.ico', 'logo.svg'],
       workbox: {
         navigateFallback: '/index.html',
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],


### PR DESCRIPTION
## Summary
- add reusable `BeepLogo` component with ping/traffic/scan/monogram variants
- replace raster logo usage and wire SVG across onboarding, header, PWA, and docs
- introduce brand color tokens and state helpers

## Testing
- `pnpm dev`
- `pnpm build` *(fails: [GenerateSW] 'fallback' property is not expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a4faae3fa88328b5245a151881913b